### PR TITLE
Replace macro with compile-time string

### DIFF
--- a/include/mbgl/shaders/mtl/collision.hpp
+++ b/include/mbgl/shaders/mtl/collision.hpp
@@ -3,11 +3,14 @@
 #include <mbgl/shaders/collision_layer_ubo.hpp>
 #include <mbgl/shaders/shader_source.hpp>
 #include <mbgl/shaders/mtl/shader_program.hpp>
+#include <mbgl/util/string.hpp>
 
 namespace mbgl {
 namespace shaders {
 
-#define COLLISION_SHADER_COMMON \
+using mbgl::util::operator""_cts;
+
+constexpr auto collisionShaderCommon =
     R"(
 
 enum {
@@ -29,21 +32,9 @@ struct alignas(16) CollisionTilePropsUBO {
     /* 16 */
 };
 static_assert(sizeof(CollisionTilePropsUBO) == 16, "wrong size");
+)"_cts;
 
-)"
-
-template <>
-struct ShaderSource<BuiltIn::CollisionBoxShader, gfx::Backend::Type::Metal> {
-    static constexpr auto name = "CollisionBoxShader";
-    static constexpr auto vertexMainFunction = "vertexMain";
-    static constexpr auto fragmentMainFunction = "fragmentMain";
-
-    static const std::array<AttributeInfo, 5> attributes;
-    static constexpr std::array<AttributeInfo, 0> instanceAttributes{};
-    static const std::array<TextureInfo, 0> textures;
-
-    static constexpr auto source = COLLISION_SHADER_COMMON R"(
-
+constexpr auto collisionBoxShaderSource = collisionShaderCommon + R"(
 struct VertexStage {
     short2 pos [[attribute(collisionUBOCount + 0)]];
     short2 anchor_pos [[attribute(collisionUBOCount + 1)]];
@@ -101,22 +92,22 @@ half4 fragment fragmentMain(FragmentStage in [[stage_in]]) {
     }
 
     return half4(color);
-}
-)";
-};
+})"_cts;
 
 template <>
-struct ShaderSource<BuiltIn::CollisionCircleShader, gfx::Backend::Type::Metal> {
-    static constexpr auto name = "CollisionCircleShader";
+struct ShaderSource<BuiltIn::CollisionBoxShader, gfx::Backend::Type::Metal> {
+    static constexpr auto name = "CollisionBoxShader";
     static constexpr auto vertexMainFunction = "vertexMain";
     static constexpr auto fragmentMainFunction = "fragmentMain";
 
-    static const std::array<AttributeInfo, 4> attributes;
+    static const std::array<AttributeInfo, 5> attributes;
     static constexpr std::array<AttributeInfo, 0> instanceAttributes{};
     static const std::array<TextureInfo, 0> textures;
 
-    static constexpr auto source = COLLISION_SHADER_COMMON R"(
+    static constexpr auto source = collisionBoxShaderSource.as_string_view();
+};
 
+constexpr auto collisionCircleShaderSource = collisionShaderCommon + R"(
 struct VertexStage {
     short2 pos [[attribute(collisionUBOCount + 0)]];
     short2 anchor_pos [[attribute(collisionUBOCount + 1)]];
@@ -194,8 +185,19 @@ half4 fragment fragmentMain(FragmentStage in [[stage_in]],
     float opacity_t = smoothstep(-stroke_width, 0.0, -distance_to_edge);
 
     return half4(opacity_t * color);
-}
-)";
+})"_cts;
+
+template <>
+struct ShaderSource<BuiltIn::CollisionCircleShader, gfx::Backend::Type::Metal> {
+    static constexpr auto name = "CollisionCircleShader";
+    static constexpr auto vertexMainFunction = "vertexMain";
+    static constexpr auto fragmentMainFunction = "fragmentMain";
+
+    static const std::array<AttributeInfo, 4> attributes;
+    static constexpr std::array<AttributeInfo, 0> instanceAttributes{};
+    static const std::array<TextureInfo, 0> textures;
+
+    static constexpr auto source = collisionCircleShaderSource.as_string_view();
 };
 
 } // namespace shaders

--- a/include/mbgl/shaders/mtl/shader_group.hpp
+++ b/include/mbgl/shaders/mtl/shader_group.hpp
@@ -63,7 +63,8 @@ public:
             addAdditionalDefines(propertiesAsUniforms, additionalDefines);
 
             auto& context = static_cast<Context&>(gfxContext);
-            const auto shaderSource = std::string(shaders::prelude) + source;
+            // C++26 will allow operator+ with std::string and std::string_view
+            const auto shaderSource = std::string(shaders::prelude) + std::string(source);
             shader = context.createProgram(
                 ShaderID, shaderName, shaderSource, vertMain, fragMain, programParameters, additionalDefines);
             assert(shader);

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -96,6 +96,75 @@ inline float stof(const std::string &str) {
     return std::stof(str);
 }
 
+// https://gist.github.com/Baduit/63c4ea0f248451f7047c1b003c8335d5
+// Note: asked author to clarify license
+
+template <std::size_t ArraySize>
+struct CompileTimeString
+{
+	constexpr CompileTimeString() noexcept = default;
+
+	constexpr CompileTimeString(const char(&literal)[ArraySize]) noexcept
+	{
+		std::ranges::copy(literal, data);
+	}
+
+	template <std::size_t OtherSize>
+	constexpr auto operator+(const CompileTimeString<OtherSize>& other) const noexcept
+	{
+		CompileTimeString<ArraySize + OtherSize - 1> result;
+		std::ranges::copy(data, result.data);
+		std::ranges::copy(other.data, result.data + ArraySize - 1);
+		return result;
+	}
+
+	// Don't count the \0 at the end
+	constexpr std::size_t size() const { return ArraySize - 1; }
+
+	constexpr auto begin() noexcept { return std::begin(data); }
+	constexpr auto end() noexcept { return std::end(data); }
+	constexpr auto cbegin() const noexcept { return std::cbegin(data); }
+	constexpr auto cend() const noexcept { return std::cend(data); }
+	constexpr auto rbegin() noexcept { return std::rbegin(data); }
+	constexpr auto rend() noexcept { return std::rend(data); }
+	constexpr auto crbegin() const noexcept { return std::crbegin(data); }
+	constexpr auto crend() const noexcept { return std::crend(data); }
+
+	template <std::size_t OtherSize>
+	constexpr bool operator==(const CompileTimeString<OtherSize>& other) const
+	{
+		return as_string_view() == other.as_string_view();
+	}
+
+
+	constexpr bool starts_with(std::string_view sv) const noexcept { return as_string_view().starts_with(sv); }
+	constexpr bool starts_with(char ch) const noexcept { return as_string_view().starts_with(ch); }
+	constexpr bool starts_with(const char* s) const { return as_string_view().starts_with(s); }
+
+	template <std::size_t OtherSize>
+	constexpr bool starts_with(const CompileTimeString<OtherSize>& other) const
+	{
+		return starts_with(other.as_string_view());
+	}
+
+	// https://en.cppreference.com/w/cpp/language/reference
+	// https://en.cppreference.com/w/cpp/language/member_functions#Member_functions_with_ref-qualifier
+	constexpr operator std::string_view() const & { return as_string_view(); }
+	constexpr operator std::string_view() const && = delete;
+
+	constexpr std::string_view as_string_view() const & { return std::string_view(data, ArraySize - 1); }
+	constexpr std::string_view as_string_view() const && = delete;
+
+	char data[ArraySize];
+};
+
+template<CompileTimeString Str>
+constexpr auto operator""_cts()
+{
+    return Str;
+}
+
+
 } // namespace util
 } // namespace mbgl
 


### PR DESCRIPTION
Still clarifying with the author of this snippet what the license is.

But we can use some kind of compile-time string instead of a macro.

Let me know what you think.